### PR TITLE
add scheduler, worker, and executor services

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -14,6 +14,9 @@ ipython = "*"
 pymongo = {extras = ["srv"], version = "*"}
 sqlalchemy = "*"
 psycopg2-binary = "*"
+redis = "*"
+rq = "*"
+schedule = "*"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a863c7851fd7099ec816fe162f6cc1dc7f785e36a7020c9f364f47b859fe263e"
+            "sha256": "fea4878e5fd7f0202498aeadfc845957e73828aa88c46b68eae333d60cfcacd2"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -30,6 +30,14 @@
                 "sha256:9a54c114f02c7a9480d56550932546a3f1fe71d8a02f1bc7ccd0ee3ee35cf4d5"
             ],
             "version": "==2.0.5"
+        },
+        "async-timeout": {
+            "hashes": [
+                "sha256:2163e1640ddb52b7a8c80d0a67a08587e5d245cc9c553a74a847056bc2976b15",
+                "sha256:8ca1e4fcf50d07413d66d1a5e416e42cfdf5851c981d679a09851a6853383b3c"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==4.0.2"
         },
         "backcall": {
             "hashes": [
@@ -61,6 +69,14 @@
             ],
             "markers": "python_version >= '3.5'",
             "version": "==5.1.1"
+        },
+        "deprecated": {
+            "hashes": [
+                "sha256:43ac5335da90c31c24ba028af536a91d41d53f9e6901ddb021bcc572ce44e38d",
+                "sha256:64756e3e14c8c5eea9795d93c524551432a0be75629f8f29e67ab8caf076c76d"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.2.13"
         },
         "dnspython": {
             "hashes": [
@@ -644,6 +660,14 @@
             ],
             "version": "==6.0"
         },
+        "redis": {
+            "hashes": [
+                "sha256:a52d5694c9eb4292770084fa8c863f79367ca19884b329ab574d5cb2036b3e54",
+                "sha256:ddf27071df4adf3821c4f2ca59d67525c3a82e5f268bed97b813cb4fabf87880"
+            ],
+            "index": "pypi",
+            "version": "==4.3.4"
+        },
         "rfc3986": {
             "extras": [
                 "idna2008"
@@ -653,6 +677,22 @@
                 "sha256:a86d6e1f5b1dc238b218b012df0aa79409667bb209e58da56d0b94704e712a97"
             ],
             "version": "==1.5.0"
+        },
+        "rq": {
+            "hashes": [
+                "sha256:62d06b44c3acfa5d1933c5a4ec3fbc2484144a8af60e318d0b8447c5236271e2",
+                "sha256:92f4cf38b2364c1697b541e77c0fe62b7e5242fa864324f262be126ee2a07e3a"
+            ],
+            "index": "pypi",
+            "version": "==1.10.1"
+        },
+        "schedule": {
+            "hashes": [
+                "sha256:617adce8b4bf38c360b781297d59918fbebfb2878f1671d189f4f4af5d0567a4",
+                "sha256:e6ca13585e62c810e13a08682e0a6a8ad245372e376ba2b8679294f377dfc8e4"
+            ],
+            "index": "pypi",
+            "version": "==1.1.0"
         },
         "six": {
             "hashes": [
@@ -851,6 +891,76 @@
                 "sha256:fc06cc8073c8e87072138ba1e431300e2d408f054b27047d047b549455066ff4"
             ],
             "version": "==10.3"
+        },
+        "wrapt": {
+            "hashes": [
+                "sha256:00b6d4ea20a906c0ca56d84f93065b398ab74b927a7a3dbd470f6fc503f95dc3",
+                "sha256:01c205616a89d09827986bc4e859bcabd64f5a0662a7fe95e0d359424e0e071b",
+                "sha256:02b41b633c6261feff8ddd8d11c711df6842aba629fdd3da10249a53211a72c4",
+                "sha256:07f7a7d0f388028b2df1d916e94bbb40624c59b48ecc6cbc232546706fac74c2",
+                "sha256:11871514607b15cfeb87c547a49bca19fde402f32e2b1c24a632506c0a756656",
+                "sha256:1b376b3f4896e7930f1f772ac4b064ac12598d1c38d04907e696cc4d794b43d3",
+                "sha256:21ac0156c4b089b330b7666db40feee30a5d52634cc4560e1905d6529a3897ff",
+                "sha256:257fd78c513e0fb5cdbe058c27a0624c9884e735bbd131935fd49e9fe719d310",
+                "sha256:2b39d38039a1fdad98c87279b48bc5dce2c0ca0d73483b12cb72aa9609278e8a",
+                "sha256:2cf71233a0ed05ccdabe209c606fe0bac7379fdcf687f39b944420d2a09fdb57",
+                "sha256:2fe803deacd09a233e4762a1adcea5db5d31e6be577a43352936179d14d90069",
+                "sha256:3232822c7d98d23895ccc443bbdf57c7412c5a65996c30442ebe6ed3df335383",
+                "sha256:34aa51c45f28ba7f12accd624225e2b1e5a3a45206aa191f6f9aac931d9d56fe",
+                "sha256:36f582d0c6bc99d5f39cd3ac2a9062e57f3cf606ade29a0a0d6b323462f4dd87",
+                "sha256:380a85cf89e0e69b7cfbe2ea9f765f004ff419f34194018a6827ac0e3edfed4d",
+                "sha256:40e7bc81c9e2b2734ea4bc1aceb8a8f0ceaac7c5299bc5d69e37c44d9081d43b",
+                "sha256:43ca3bbbe97af00f49efb06e352eae40434ca9d915906f77def219b88e85d907",
+                "sha256:4fcc4649dc762cddacd193e6b55bc02edca674067f5f98166d7713b193932b7f",
+                "sha256:5a0f54ce2c092aaf439813735584b9537cad479575a09892b8352fea5e988dc0",
+                "sha256:5a9a0d155deafd9448baff28c08e150d9b24ff010e899311ddd63c45c2445e28",
+                "sha256:5b02d65b9ccf0ef6c34cba6cf5bf2aab1bb2f49c6090bafeecc9cd81ad4ea1c1",
+                "sha256:60db23fa423575eeb65ea430cee741acb7c26a1365d103f7b0f6ec412b893853",
+                "sha256:642c2e7a804fcf18c222e1060df25fc210b9c58db7c91416fb055897fc27e8cc",
+                "sha256:6a9a25751acb379b466ff6be78a315e2b439d4c94c1e99cb7266d40a537995d3",
+                "sha256:6b1a564e6cb69922c7fe3a678b9f9a3c54e72b469875aa8018f18b4d1dd1adf3",
+                "sha256:6d323e1554b3d22cfc03cd3243b5bb815a51f5249fdcbb86fda4bf62bab9e164",
+                "sha256:6e743de5e9c3d1b7185870f480587b75b1cb604832e380d64f9504a0535912d1",
+                "sha256:709fe01086a55cf79d20f741f39325018f4df051ef39fe921b1ebe780a66184c",
+                "sha256:7b7c050ae976e286906dd3f26009e117eb000fb2cf3533398c5ad9ccc86867b1",
+                "sha256:7d2872609603cb35ca513d7404a94d6d608fc13211563571117046c9d2bcc3d7",
+                "sha256:7ef58fb89674095bfc57c4069e95d7a31cfdc0939e2a579882ac7d55aadfd2a1",
+                "sha256:80bb5c256f1415f747011dc3604b59bc1f91c6e7150bd7db03b19170ee06b320",
+                "sha256:81b19725065dcb43df02b37e03278c011a09e49757287dca60c5aecdd5a0b8ed",
+                "sha256:833b58d5d0b7e5b9832869f039203389ac7cbf01765639c7309fd50ef619e0b1",
+                "sha256:88bd7b6bd70a5b6803c1abf6bca012f7ed963e58c68d76ee20b9d751c74a3248",
+                "sha256:8ad85f7f4e20964db4daadcab70b47ab05c7c1cf2a7c1e51087bfaa83831854c",
+                "sha256:8c0ce1e99116d5ab21355d8ebe53d9460366704ea38ae4d9f6933188f327b456",
+                "sha256:8d649d616e5c6a678b26d15ece345354f7c2286acd6db868e65fcc5ff7c24a77",
+                "sha256:903500616422a40a98a5a3c4ff4ed9d0066f3b4c951fa286018ecdf0750194ef",
+                "sha256:9736af4641846491aedb3c3f56b9bc5568d92b0692303b5a305301a95dfd38b1",
+                "sha256:988635d122aaf2bdcef9e795435662bcd65b02f4f4c1ae37fbee7401c440b3a7",
+                "sha256:9cca3c2cdadb362116235fdbd411735de4328c61425b0aa9f872fd76d02c4e86",
+                "sha256:9e0fd32e0148dd5dea6af5fee42beb949098564cc23211a88d799e434255a1f4",
+                "sha256:9f3e6f9e05148ff90002b884fbc2a86bd303ae847e472f44ecc06c2cd2fcdb2d",
+                "sha256:a85d2b46be66a71bedde836d9e41859879cc54a2a04fad1191eb50c2066f6e9d",
+                "sha256:a9a52172be0b5aae932bef82a79ec0a0ce87288c7d132946d645eba03f0ad8a8",
+                "sha256:aa31fdcc33fef9eb2552cbcbfee7773d5a6792c137b359e82879c101e98584c5",
+                "sha256:b014c23646a467558be7da3d6b9fa409b2c567d2110599b7cf9a0c5992b3b471",
+                "sha256:b21bb4c09ffabfa0e85e3a6b623e19b80e7acd709b9f91452b8297ace2a8ab00",
+                "sha256:b5901a312f4d14c59918c221323068fad0540e34324925c8475263841dbdfe68",
+                "sha256:b9b7a708dd92306328117d8c4b62e2194d00c365f18eff11a9b53c6f923b01e3",
+                "sha256:d1967f46ea8f2db647c786e78d8cc7e4313dbd1b0aca360592d8027b8508e24d",
+                "sha256:d52a25136894c63de15a35bc0bdc5adb4b0e173b9c0d07a2be9d3ca64a332735",
+                "sha256:d77c85fedff92cf788face9bfa3ebaa364448ebb1d765302e9af11bf449ca36d",
+                "sha256:d79d7d5dc8a32b7093e81e97dad755127ff77bcc899e845f41bf71747af0c569",
+                "sha256:dbcda74c67263139358f4d188ae5faae95c30929281bc6866d00573783c422b7",
+                "sha256:ddaea91abf8b0d13443f6dac52e89051a5063c7d014710dcb4d4abb2ff811a59",
+                "sha256:dee0ce50c6a2dd9056c20db781e9c1cfd33e77d2d569f5d1d9321c641bb903d5",
+                "sha256:dee60e1de1898bde3b238f18340eec6148986da0455d8ba7848d50470a7a32fb",
+                "sha256:e2f83e18fe2f4c9e7db597e988f72712c0c3676d337d8b101f6758107c42425b",
+                "sha256:e3fb1677c720409d5f671e39bac6c9e0e422584e5f518bfd50aa4cbbea02433f",
+                "sha256:ee2b1b1769f6707a8a445162ea16dddf74285c3964f605877a20e38545c3c462",
+                "sha256:ee6acae74a2b91865910eef5e7de37dc6895ad96fa23603d1d27ea69df545015",
+                "sha256:ef3f72c9666bba2bab70d2a8b79f2c6d2c1a42a7f7e2b0ec83bb2f9e383950af"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==1.14.1"
         }
     },
     "develop": {}

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,3 @@
 web: uvicorn main:app --host 0.0.0.0 --port $PORT
+worker: python worker.py
+clock: python clock.py

--- a/clock.py
+++ b/clock.py
@@ -1,0 +1,29 @@
+
+# from apscheduler.schedulers.blocking import BlockingScheduler
+
+# from service import run_service
+
+# sched = BlockingScheduler()
+
+# @sched.scheduled_job('interval', minutes=3)
+# def timed_job():
+#     print("something")
+
+# # @sched.scheduled_job('cron', day_of_week='mon-fri', hour=15, minute=30)
+# # def scheduled_job():
+# #     print('This job is run every weekday at 5pm.')
+
+# sched.start()
+
+
+import time
+
+import schedule
+
+from service import add_service_to_queue
+
+schedule.every().monday.at("06:00").do(add_service_to_queue)
+
+while True:
+    schedule.run_pending()
+    time.sleep(1)

--- a/service.py
+++ b/service.py
@@ -1,0 +1,59 @@
+
+from datetime import datetime, timedelta
+import logging
+from typing import Union
+from logging import Logger
+
+from rq import Queue
+
+from src.redash_util import q1
+from src.db_util import results_insert
+
+from worker import conn
+
+logger = Logger("service.py")
+logger.setLevel(logging.DEBUG)
+
+def remove_timestamp(date: datetime, text:bool = True) -> Union[datetime, str]:
+    if text:
+        return f"{date.year}-{date.month}-{date.day}"
+    else:
+        return datetime(date.year, date.month, date.day)
+
+def run_query():
+
+    # get last week's start and end
+    today = datetime.today()
+    
+    lastweek = today - timedelta(days=7)
+    lastweek_start = lastweek - timedelta(days=lastweek.weekday())
+    lastweek_start = lastweek_start.replace(hour=0, minute=0, second=0, microsecond=0)
+
+    lastweek_end = lastweek_start + timedelta(days=6)
+    lastweek_end = lastweek_end.replace(hour=23, minute=59, second=59, microsecond=0)
+
+    result = q1.result(lastweek_start, lastweek_end)
+
+    key = f"{remove_timestamp(lastweek_start)}_{remove_timestamp(lastweek_end)}"
+
+    return key, result
+
+def cache_results(key, result):
+    """Write query result to the database"""
+
+    status = results_insert(key, result, datetime.now())
+    if status > 0:
+        # log success
+        pass
+    else:
+        # log error
+        pass
+
+def run_service():
+    key, result = run_query()
+    cache_results(key, result)
+
+def add_service_to_queue():
+    logger.info("queuing service")
+    q = Queue(connection=conn)
+    q.enqueue(run_service)

--- a/src/db_util.py
+++ b/src/db_util.py
@@ -7,7 +7,7 @@ from sqlalchemy import create_engine, Table, Column, Integer, String, DateTime, 
 env = Env()
 env.read_env()
 
-PG_URI = env('PG_URI')
+PG_URI = env('DATABASE')
 
 engine = create_engine(f'postgresql://{PG_URI}')
 
@@ -45,5 +45,5 @@ def results_insert(key:str, result:str, created_at:datetime):
         return result.rowcount
     except:
         # raise
-        
+
         return 0

--- a/worker.py
+++ b/worker.py
@@ -1,49 +1,20 @@
 
-from datetime import datetime, timedelta
-from typing import Union
+from environs import Env
 
-from src.redash_util import q1
-from src.db_util import results_insert
-
-def remove_timestamp(date: datetime, text:bool = True) -> Union[datetime, str]:
-    if text:
-        return f"{date.year}-{date.month}-{date.day}"
-    else:
-        return datetime(date.year, date.month, date.day)
-
-def run_query():
-
-    # get last week's start and end
-    today = datetime.today()
-    
-    lastweek = today - timedelta(days=7)
-    lastweek_start = lastweek - timedelta(days=lastweek.weekday())
-    lastweek_start = lastweek_start.replace(hour=0, minute=0, second=0, microsecond=0)
-
-    lastweek_end = lastweek_start + timedelta(days=6)
-    lastweek_end = lastweek_end.replace(hour=23, minute=59, second=59, microsecond=0)
-
-    result = q1.result(lastweek_start, lastweek_end)
-
-    key = f"{remove_timestamp(lastweek_start)}_{remove_timestamp(lastweek_end)}"
-
-    return key, result
-
-def cache_results(key, result):
-    """Write query result to the database"""
-
-    status = results_insert(key, result, datetime.now())
-    if status > 0:
-        # log success
-        pass
-    else:
-        # log error
-        pass
-
-def run_service():
-    key, result = run_query()
-    cache_results(key, result)
+import redis
+from rq import Worker, Queue, Connection
 
 
-if __name__ == "__main__":
-    run_service()
+env = Env()
+env.read_env()
+
+listen = ['high', 'default', 'low']
+
+redis_url = env('REDIS', default='redis://localhost:6379')
+
+conn = redis.from_url(redis_url)
+
+if __name__ == '__main__':
+    with Connection(conn):
+        worker = Worker(map(Queue, listen))
+        worker.work()


### PR DESCRIPTION
add several changes to make scheduling work on heroku

ideal:
heroku picks up scheduling details in clock.py >
     the scheduler (clock.py) loads the work to be done (service.run_service) into redis to be picked up by the worker >
          the worker picks up the new task and executes it >
               on execution, the query is run and the results stored in a postgres db (persistence)
end of chain.